### PR TITLE
Problems 

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,7 @@
 (function() {
   var FFI, fs, libc, tmpDir, uniqId, uniqIdK;
 
-  FFI = require("node-ffi");
+  FFI = require("ffi");
 
   libc = new FFI.Library(null, {
     "system": ["int32", ["string"]]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "author": "Jeremy Faivre <contact@jeremyfa.com>",
     "main": "./bin/index.js",
     "dependencies": {
-        "node-ffi": ">=0.5.0"
+        "ffi": "=1.0.1"
     },
     "devDependencies": {
         "coffee-script": ">=1.2.0",


### PR DESCRIPTION
Hi,

I ran into this error:

```
  SOLINK_MODULE(target) Release/obj.target/ffi_bindings.node
/usr/bin/ld: /home/alt/projects/node-exec-sync/node_modules/node-ffi/deps/libffi/.libs/libffi.a(closures.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/home/alt/projects/node-exec-sync/node_modules/node-ffi/deps/libffi/.libs/libffi.a: could not read symbols: Bad value
collect2: error: ld returned 1 exit status
make: *** [Release/obj.target/ffi_bindings.node] Error 1
make: Leaving directory `/home/alt/projects/node-exec-sync/node_modules/node-ffi/build'
ERR! Error: `make` failed with exit code: 2
    at ChildProcess.onExit (/home/alt/install/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:212:23)
    at ChildProcess.emit (events.js:70:17)
    at maybeExit (child_process.js:362:16)
    at Process.onexit (child_process.js:398:5)
ERR! not ok

npm ERR! node-ffi@0.5.5 install: `node-gyp rebuild`
npm ERR! `sh "-c" "node-gyp rebuild"` failed with 1
npm ERR! 
npm ERR! Failed at the node-ffi@0.5.5 install script.
...
```

while running `npm install`.  Changing from `node-ffi`to `ffi` v1.0.1 fixes this
problem for me and execSync functions.

Cheers!
