### PR TITLE
Update ffi dependency to enable building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ $ curl http://npmjs.org/install.sh | sh
 $ cd /path/to/your/project
 $ [sudo] npm install exec-sync
 ```
+Warning: Only the 32-bit version of Node.js (node-v0.x.y-x86) is supported under Windows.
 
 ### Using exec-sync from node.js
 Warning: use only for special operation or command line scripts written with node. Don't use this for regular server code or it will ruin the responsiveness of your server.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "author": "Jeremy Faivre <contact@jeremyfa.com>",
     "main": "./bin/index.js",
     "dependencies": {
-        "ffi": "=1.0.1"
+        "ffi": ">=1.0.7"
     },
     "devDependencies": {
         "coffee-script": ">=1.2.0",


### PR DESCRIPTION
The 1.0.1 version did not work for me (tested on several machines). Updating to 1.0.7 did the trick.

I've also added a note to use 32-bit Node.js as ffi does not seem to work with the 64-version.
