### PR TITLE
Problems installing exec-sync on windows with ffi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "author": "Jeremy Faivre <contact@jeremyfa.com>",
     "main": "./bin/index.js",
     "dependencies": {
-        "ffi": "=1.0.1"
+        "ffi": "=1.1.2"
     },
     "devDependencies": {
         "coffee-script": ">=1.2.0",


### PR DESCRIPTION
Hi Jeremy,

I had problems installing exec-sync on windows with your current package configuration.  The version of FFI that it tries to install fails to properly install on windows 7.  Later versions of ffi work fine.  I've bumped up the version in this pull request to one that worked for us.  It would be awesome if you could accept this version bump to make things compatible with windows 7 again.

Ben
