### PR TITLE
Updating version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "exec-sync",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Execute shell command synchronously. Use this for migration scripts, cli programs, but not for regular server code.",
     "keywords": [
     "exec",


### PR DESCRIPTION
Updating version so NPM registry will pull correct FFI.  

As it stands, when you do a `npm install exec-sync` its pulling
FFI 1.0.1 instead of 1.1.2 which has critical windows fixes.
